### PR TITLE
login: set AWS keys

### DIFF
--- a/login.go
+++ b/login.go
@@ -48,6 +48,7 @@ func runLogin(args *LoginCmd) error {
 	if admin {
 		args.role = "admin"
 		if strings.EqualFold(os.Getenv("BITTE_PROVIDER"), "AWS") {
+			os.Unsetenv("AWS_PROFILE")
 			if err := loginAWS(args); err != nil {
 				return err
 			}


### PR DESCRIPTION
Set's the AWS login keys as environmental variables to avoid having to manually update them when they expire. Currently, if `AWS_PROFILE` is set but an entry doesn't exist for it in the credentials file, this will error, therefore, I simply unset `AWS_PROFILE` before the login check to avoid this. Tested this functionality and it should be ready to go.

Resolves #3